### PR TITLE
Implement SDL-powered runtime loop and demo

### DIFF
--- a/ChaosEngine/examples/00_boot/main.c
+++ b/ChaosEngine/examples/00_boot/main.c
@@ -1,3 +1,133 @@
 #include "runtime/chaos_engine.h"
+#include "utility/chaos_math.h"
+#include "utility/chaos_string.h"
 
-int main(void){ return 0; }
+typedef struct boot_state_s
+{
+    ce_f32 pos_x;
+    ce_f32 pos_y;
+    ce_f32 speed;
+    ce_color background;
+    ce_color player_color;
+} boot_state;
+
+static ce_bool boot_on_init(ce_engine* engine, void* user_data)
+{
+    boot_state* state = (boot_state*)user_data;
+    ce_window* window = ce_engine_window(engine);
+
+    if ((state == (boot_state*)0) || (window == (ce_window*)0))
+    {
+        return CE_FALSE;
+    }
+
+    state->speed = 240.0f;
+    state->background = ce_color_rgb(12u, 10u, 30u);
+    state->player_color = ce_color_rgb(230u, 120u, 70u);
+
+    ce_window_set_clear_color(window, state->background);
+    state->pos_x = (ce_f32)(engine->config.window.width / 2 - 32);
+    state->pos_y = (ce_f32)(engine->config.window.height / 2 - 32);
+
+    CE_LOG_INFO("ChaosEngine demo booted");
+    return CE_TRUE;
+}
+
+static void boot_on_update(ce_engine* engine, void* user_data, ce_f32 dt)
+{
+    const ce_input_state* input = ce_engine_input(engine);
+    boot_state*           state = (boot_state*)user_data;
+    ce_f32                dir_x;
+    ce_f32                dir_y;
+
+    if ((state == (boot_state*)0) || (input == (const ce_input_state*)0))
+    {
+        return;
+    }
+
+    dir_x = 0.0f;
+    dir_y = 0.0f;
+
+    if (ce_input_key_down(input, CE_KEY_A) || ce_input_key_down(input, CE_KEY_LEFT))
+    {
+        dir_x -= 1.0f;
+    }
+    if (ce_input_key_down(input, CE_KEY_D) || ce_input_key_down(input, CE_KEY_RIGHT))
+    {
+        dir_x += 1.0f;
+    }
+    if (ce_input_key_down(input, CE_KEY_W) || ce_input_key_down(input, CE_KEY_UP))
+    {
+        dir_y -= 1.0f;
+    }
+    if (ce_input_key_down(input, CE_KEY_S) || ce_input_key_down(input, CE_KEY_DOWN))
+    {
+        dir_y += 1.0f;
+    }
+
+    if ((dir_x != 0.0f) || (dir_y != 0.0f))
+    {
+        ce_f32 length = ce_sqrt((dir_x * dir_x) + (dir_y * dir_y));
+        if (length > 0.0f)
+        {
+            dir_x /= length;
+            dir_y /= length;
+        }
+        state->pos_x += dir_x * state->speed * dt;
+        state->pos_y += dir_y * state->speed * dt;
+    }
+
+    if (ce_input_key_pressed(input, CE_KEY_ESCAPE))
+    {
+        ce_engine_request_exit(engine);
+    }
+}
+
+static void boot_on_render(ce_engine* engine, void* user_data, ce_f32 alpha)
+{
+    boot_state* state = (boot_state*)user_data;
+    ce_window*  window = ce_engine_window(engine);
+    ce_s32      draw_x;
+    ce_s32      draw_y;
+
+    (void)alpha;
+
+    if ((state == (boot_state*)0) || (window == (ce_window*)0))
+    {
+        return;
+    }
+
+    draw_x = (ce_s32)state->pos_x;
+    draw_y = (ce_s32)state->pos_y;
+
+    ce_window_draw_filled_rect(window, draw_x, draw_y, 64, 64, state->player_color);
+    ce_window_draw_rect(window, draw_x - 2, draw_y - 2, 68, 68, ce_color_rgb(255u, 255u, 255u));
+}
+
+static void boot_on_shutdown(ce_engine* engine, void* user_data)
+{
+    (void)engine;
+    (void)user_data;
+    CE_LOG_INFO("ChaosEngine demo shutdown");
+}
+
+int main(void)
+{
+    ce_engine_config     config;
+    ce_engine_callbacks  callbacks;
+    boot_state           state;
+
+    config = ce_engine_config_default();
+    config.window.title  = "ChaosEngine Boot Demo";
+    config.window.vsync  = CE_TRUE;
+    config.target_fps    = 60u;
+
+    callbacks.on_init     = boot_on_init;
+    callbacks.on_update   = boot_on_update;
+    callbacks.on_render   = boot_on_render;
+    callbacks.on_shutdown = boot_on_shutdown;
+
+    ce__memset(&state, 0u, sizeof(state));
+
+    return (ce_engine_run(&config, &callbacks, &state) == CE_OK) ? 0 : 1;
+}

--- a/ChaosEngine/inc/core/chaos_log.h
+++ b/ChaosEngine/inc/core/chaos_log.h
@@ -15,6 +15,62 @@
 #ifndef CHAOS_LOG_H
 #define CHAOS_LOG_H
 
-/* Public API skeleton */
+#include "core/chaos_types.h"
+
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Runtime log severity levels.
+ */
+typedef enum ce_log_level_e
+{
+    CE_LOG_TRACE = 0,
+    CE_LOG_DEBUG = 1,
+    CE_LOG_INFO  = 2,
+    CE_LOG_WARN  = 3,
+    CE_LOG_ERROR = 4,
+    CE_LOG_FATAL = 5
+} ce_log_level;
+
+/**
+ * @brief Sets the minimum level that will be printed to the log sink.
+ */
+void ce_log_set_level(ce_log_level level);
+
+/**
+ * @brief Returns the current logging level threshold.
+ */
+ce_log_level ce_log_get_level(void);
+
+/**
+ * @brief Enables or disables timestamps in log output.
+ */
+void ce_log_enable_timestamp(ce_bool enabled);
+
+/**
+ * @brief Writes a formatted log message.
+ */
+void ce_log_message(ce_log_level level, const ce_char* fmt, ...);
+
+/**
+ * @brief Variant of @ref ce_log_message that accepts a va_list.
+ */
+void ce_log_messagev(ce_log_level level, const ce_char* fmt, va_list args);
+
+/* Convenience macros */
+#define CE_LOG_TRACE(...) ce_log_message(CE_LOG_TRACE, __VA_ARGS__)
+#define CE_LOG_DEBUG(...) ce_log_message(CE_LOG_DEBUG, __VA_ARGS__)
+#define CE_LOG_INFO(...)  ce_log_message(CE_LOG_INFO,  __VA_ARGS__)
+#define CE_LOG_WARN(...)  ce_log_message(CE_LOG_WARN,  __VA_ARGS__)
+#define CE_LOG_ERROR(...) ce_log_message(CE_LOG_ERROR, __VA_ARGS__)
+#define CE_LOG_FATAL(...) ce_log_message(CE_LOG_FATAL, __VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CHAOS_LOG_H */

--- a/ChaosEngine/inc/platform/chaos_input.h
+++ b/ChaosEngine/inc/platform/chaos_input.h
@@ -15,6 +15,161 @@
 #ifndef CHAOS_INPUT_H
 #define CHAOS_INPUT_H
 
-/* Public API skeleton */
+#include "core/chaos_types.h"
+
+#include <SDL2/SDL.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Supported keyboard keys for ChaosEngine input.
+ */
+typedef enum ce_key_e
+{
+    CE_KEY_UNKNOWN = 0,
+    CE_KEY_ESCAPE,
+    CE_KEY_SPACE,
+    CE_KEY_RETURN,
+    CE_KEY_TAB,
+    CE_KEY_BACKSPACE,
+    CE_KEY_LEFT,
+    CE_KEY_RIGHT,
+    CE_KEY_UP,
+    CE_KEY_DOWN,
+    CE_KEY_A,
+    CE_KEY_B,
+    CE_KEY_C,
+    CE_KEY_D,
+    CE_KEY_E,
+    CE_KEY_F,
+    CE_KEY_G,
+    CE_KEY_H,
+    CE_KEY_I,
+    CE_KEY_J,
+    CE_KEY_K,
+    CE_KEY_L,
+    CE_KEY_M,
+    CE_KEY_N,
+    CE_KEY_O,
+    CE_KEY_P,
+    CE_KEY_Q,
+    CE_KEY_R,
+    CE_KEY_S,
+    CE_KEY_T,
+    CE_KEY_U,
+    CE_KEY_V,
+    CE_KEY_W,
+    CE_KEY_X,
+    CE_KEY_Y,
+    CE_KEY_Z,
+    CE_KEY_0,
+    CE_KEY_1,
+    CE_KEY_2,
+    CE_KEY_3,
+    CE_KEY_4,
+    CE_KEY_5,
+    CE_KEY_6,
+    CE_KEY_7,
+    CE_KEY_8,
+    CE_KEY_9,
+    CE_KEY_LSHIFT,
+    CE_KEY_RSHIFT,
+    CE_KEY_LCTRL,
+    CE_KEY_RCTRL,
+    CE_KEY_LALT,
+    CE_KEY_RALT,
+    CE_KEY_COUNT
+} ce_key;
+
+/**
+ * @brief Mouse buttons tracked by the input subsystem.
+ */
+typedef enum ce_mouse_button_e
+{
+    CE_MOUSE_LEFT = 0,
+    CE_MOUSE_RIGHT,
+    CE_MOUSE_MIDDLE,
+    CE_MOUSE_X1,
+    CE_MOUSE_X2,
+    CE_MOUSE_BUTTON_COUNT
+} ce_mouse_button;
+
+/**
+ * @brief Aggregate state for keyboard and mouse per-frame.
+ */
+typedef struct ce_input_state_s
+{
+    ce_bool key_down[CE_KEY_COUNT];
+    ce_bool key_pressed[CE_KEY_COUNT];
+    ce_bool key_released[CE_KEY_COUNT];
+
+    ce_bool mouse_down[CE_MOUSE_BUTTON_COUNT];
+    ce_bool mouse_pressed[CE_MOUSE_BUTTON_COUNT];
+    ce_bool mouse_released[CE_MOUSE_BUTTON_COUNT];
+
+    ce_s32 mouse_x;
+    ce_s32 mouse_y;
+    ce_s32 mouse_delta_x;
+    ce_s32 mouse_delta_y;
+
+    ce_s32 scroll_x;
+    ce_s32 scroll_y;
+} ce_input_state;
+
+/**
+ * @brief Initializes an input state structure.
+ */
+void ce_input_init(ce_input_state* state);
+
+/**
+ * @brief Clears transient pressed/released flags before processing a frame.
+ */
+void ce_input_new_frame(ce_input_state* state);
+
+/**
+ * @brief Processes a key transition.
+ */
+void ce_input_handle_key(ce_input_state* state, ce_key key, ce_bool is_down);
+
+/**
+ * @brief Processes a mouse button transition.
+ */
+void ce_input_handle_mouse_button(ce_input_state* state, ce_mouse_button button, ce_bool is_down);
+
+/**
+ * @brief Updates mouse coordinates and delta.
+ */
+void ce_input_handle_mouse_motion(ce_input_state* state, ce_s32 x, ce_s32 y, ce_s32 dx, ce_s32 dy);
+
+/**
+ * @brief Updates scroll wheel data.
+ */
+void ce_input_handle_mouse_wheel(ce_input_state* state, ce_s32 dx, ce_s32 dy);
+
+/**
+ * @brief Convenience wrapper processing an SDL_Event.
+ */
+void ce_input_process_event(ce_input_state* state, const SDL_Event* event);
+
+ce_bool ce_input_key_down(const ce_input_state* state, ce_key key);
+ce_bool ce_input_key_pressed(const ce_input_state* state, ce_key key);
+ce_bool ce_input_key_released(const ce_input_state* state, ce_key key);
+
+ce_bool ce_input_mouse_down(const ce_input_state* state, ce_mouse_button button);
+ce_bool ce_input_mouse_pressed(const ce_input_state* state, ce_mouse_button button);
+ce_bool ce_input_mouse_released(const ce_input_state* state, ce_mouse_button button);
+
+ce_s32 ce_input_mouse_x(const ce_input_state* state);
+ce_s32 ce_input_mouse_y(const ce_input_state* state);
+ce_s32 ce_input_mouse_delta_x(const ce_input_state* state);
+ce_s32 ce_input_mouse_delta_y(const ce_input_state* state);
+ce_s32 ce_input_scroll_x(const ce_input_state* state);
+ce_s32 ce_input_scroll_y(const ce_input_state* state);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CHAOS_INPUT_H */

--- a/ChaosEngine/inc/platform/chaos_window.h
+++ b/ChaosEngine/inc/platform/chaos_window.h
@@ -15,6 +15,112 @@
 #ifndef CHAOS_WINDOW_H
 #define CHAOS_WINDOW_H
 
-/* Public API skeleton */
+#include "core/chaos_types.h"
+#include "core/chaos_error.h"
+
+#include <SDL2/SDL.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief RGBA color helper structure.
+ */
+typedef struct ce_color_s
+{
+    ce_u8 r;
+    ce_u8 g;
+    ce_u8 b;
+    ce_u8 a;
+} ce_color;
+
+/**
+ * @brief Utility constructor for ce_color.
+ */
+static inline ce_color ce_color_rgba(ce_u8 r, ce_u8 g, ce_u8 b, ce_u8 a)
+{
+    ce_color c;
+    c.r = r;
+    c.g = g;
+    c.b = b;
+    c.a = a;
+    return c;
+}
+
+/**
+ * @brief Utility constructor for opaque RGB colors.
+ */
+static inline ce_color ce_color_rgb(ce_u8 r, ce_u8 g, ce_u8 b)
+{
+    return ce_color_rgba(r, g, b, 255u);
+}
+
+/**
+ * @brief Window creation description.
+ */
+typedef struct ce_window_config_s
+{
+    const ce_char* title;
+    ce_s32         width;
+    ce_s32         height;
+    ce_bool        resizable;
+    ce_bool        vsync;
+} ce_window_config;
+
+/**
+ * @brief Runtime window state.
+ */
+typedef struct ce_window_s
+{
+    SDL_Window*   native_window;
+    SDL_Renderer* native_renderer;
+    ce_window_config config;
+    ce_color         clear_color;
+} ce_window;
+
+/**
+ * @brief Initializes a window using SDL2.
+ */
+ce_result ce_window_create(const ce_window_config* config, ce_window* out_window);
+
+/**
+ * @brief Destroys an existing window.
+ */
+void ce_window_destroy(ce_window* window);
+
+/**
+ * @brief Sets the clear color used when calling @ref ce_window_clear.
+ */
+void ce_window_set_clear_color(ce_window* window, ce_color color);
+
+/**
+ * @brief Clears the current back buffer with the configured clear color.
+ */
+void ce_window_clear(ce_window* window);
+
+/**
+ * @brief Presents the back buffer to the screen.
+ */
+void ce_window_present(ce_window* window);
+
+/**
+ * @brief Draws a filled rectangle using the SDL renderer backend.
+ */
+void ce_window_draw_filled_rect(ce_window* window, ce_s32 x, ce_s32 y, ce_s32 w, ce_s32 h, ce_color color);
+
+/**
+ * @brief Draws a rectangle outline using the SDL renderer backend.
+ */
+void ce_window_draw_rect(ce_window* window, ce_s32 x, ce_s32 y, ce_s32 w, ce_s32 h, ce_color color);
+
+/**
+ * @brief Returns the underlying SDL_Renderer pointer.
+ */
+SDL_Renderer* ce_window_renderer(ce_window* window);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CHAOS_WINDOW_H */

--- a/ChaosEngine/inc/runtime/chaos_engine.h
+++ b/ChaosEngine/inc/runtime/chaos_engine.h
@@ -15,6 +15,115 @@
 #ifndef CHAOS_ENGINE_H
 #define CHAOS_ENGINE_H
 
-/* Public API skeleton */
+#include "core/chaos_types.h"
+#include "core/chaos_error.h"
+#include "core/chaos_time.h"
+#include "core/chaos_log.h"
+#include "platform/chaos_window.h"
+#include "platform/chaos_input.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct ce_engine_s;
+typedef struct ce_engine_s ce_engine;
+
+/**
+ * @brief Callback invoked during engine initialization.
+ */
+typedef ce_bool (*ce_engine_init_fn)(ce_engine* engine, void* user_data);
+
+/**
+ * @brief Callback invoked during each fixed-timestep update.
+ */
+typedef void (*ce_engine_update_fn)(ce_engine* engine, void* user_data, ce_f32 dt);
+
+/**
+ * @brief Callback invoked to render a frame. Alpha is the interpolation factor in [0,1].
+ */
+typedef void (*ce_engine_render_fn)(ce_engine* engine, void* user_data, ce_f32 alpha);
+
+/**
+ * @brief Callback invoked before shutting down the engine.
+ */
+typedef void (*ce_engine_shutdown_fn)(ce_engine* engine, void* user_data);
+
+/**
+ * @brief Aggregated callbacks to run a game/application.
+ */
+typedef struct ce_engine_callbacks_s
+{
+    ce_engine_init_fn     on_init;
+    ce_engine_update_fn   on_update;
+    ce_engine_render_fn   on_render;
+    ce_engine_shutdown_fn on_shutdown;
+} ce_engine_callbacks;
+
+/**
+ * @brief Engine configuration structure.
+ */
+typedef struct ce_engine_config_s
+{
+    ce_window_config window;
+    ce_u32           target_fps;
+    ce_u32           max_updates_per_frame;
+} ce_engine_config;
+
+/**
+ * @brief Runtime engine state.
+ */
+struct ce_engine_s
+{
+    ce_engine_config config;
+    ce_engine_callbacks callbacks;
+    ce_bool         running;
+    ce_f32          fixed_dt;
+    ce_f32          accumulator;
+    ce_f32          elapsed_time;
+    ce_u64          frame_index;
+    ce_window       window;
+    ce_input_state  input;
+    void*           user_data;
+};
+
+/**
+ * @brief Returns a default configuration with sensible values.
+ */
+ce_engine_config ce_engine_config_default(void);
+
+/**
+ * @brief Boots the engine and runs the main loop until exit.
+ */
+ce_result ce_engine_run(const ce_engine_config* config, const ce_engine_callbacks* callbacks, void* user_data);
+
+/**
+ * @brief Requests termination of the main loop at the next iteration.
+ */
+void ce_engine_request_exit(ce_engine* engine);
+
+/**
+ * @brief Accessor for the current input state.
+ */
+const ce_input_state* ce_engine_input(const ce_engine* engine);
+
+/**
+ * @brief Accessor for the engine window.
+ */
+ce_window* ce_engine_window(ce_engine* engine);
+
+/**
+ * @brief Returns the total elapsed time since the engine started.
+ */
+ce_f32 ce_engine_elapsed_time(const ce_engine* engine);
+
+/**
+ * @brief Returns the number of rendered frames.
+ */
+ce_u64 ce_engine_frame_index(const ce_engine* engine);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CHAOS_ENGINE_H */

--- a/ChaosEngine/src/core/chaos_log.c
+++ b/ChaosEngine/src/core/chaos_log.c
@@ -1,16 +1,150 @@
 /**
- * 
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░ 
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░   
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░ 
- * 
+ *
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░
+ *
  * @file chaos_log.c
- * @brief Implementation skeleton.
+ * @brief Minimal logging implementation for ChaosEngine.
  */
+
 #include "core/chaos_log.h"
 
-/* TODO: implement */
+#include "core/chaos_error.h"
+#include "utility/chaos_string.h"
+
+#include <stdio.h>
+#include <stdarg.h>
+#include <time.h>
+
+/* ************************************************************************** */
+/* INTERNAL STATE                                                             */
+/* ************************************************************************** */
+
+/** @brief Currently selected minimum log level. */
+static ce_log_level g_log_level = CE_LOG_INFO;
+/** @brief Enable printing timestamps when CE_TRUE. */
+static ce_bool g_log_timestamp_enabled = CE_TRUE;
+
+/* ************************************************************************** */
+/* INTERNAL HELPERS                                                           */
+/* ************************************************************************** */
+
+/**
+ * @brief Returns the printable label associated with a log level.
+ */
+static const ce_char* ce__log_level_label(ce_log_level level)
+{
+    switch (level)
+    {
+        case CE_LOG_TRACE: return "TRACE";
+        case CE_LOG_DEBUG: return "DEBUG";
+        case CE_LOG_INFO:  return "INFO";
+        case CE_LOG_WARN:  return "WARN";
+        case CE_LOG_ERROR: return "ERROR";
+        case CE_LOG_FATAL: return "FATAL";
+        default:           return "LOG";
+    }
+}
+
+/**
+ * @brief Returns the FILE* stream to use for a given level.
+ */
+static FILE* ce__log_stream_for_level(ce_log_level level)
+{
+    if (level >= CE_LOG_ERROR)
+    {
+        return stderr;
+    }
+    return stdout;
+}
+
+/* ************************************************************************** */
+/* PUBLIC API                                                                 */
+/* ************************************************************************** */
+
+void ce_log_set_level(ce_log_level level)
+{
+    g_log_level = level;
+}
+
+ce_log_level ce_log_get_level(void)
+{
+    return g_log_level;
+}
+
+void ce_log_enable_timestamp(ce_bool enabled)
+{
+    g_log_timestamp_enabled = enabled;
+}
+
+void ce_log_message(ce_log_level level, const ce_char* fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    ce_log_messagev(level, fmt, args);
+    va_end(args);
+}
+
+void ce_log_messagev(ce_log_level level, const ce_char* fmt, va_list args)
+{
+    FILE*       stream;
+    ce_char     buffer[1024];
+    ce_size     len;
+    time_t      now;
+    struct tm   local_tm;
+    ce_char     timestamp[64];
+
+    if (fmt == (const ce_char*)0)
+    {
+        return;
+    }
+
+    if (level < g_log_level)
+    {
+        return;
+    }
+
+    stream = ce__log_stream_for_level(level);
+    len    = (ce_size)0;
+
+    if (g_log_timestamp_enabled == CE_TRUE)
+    {
+        now = time((time_t*)0);
+#if defined(_MSC_VER)
+        localtime_s(&local_tm, &now);
+#else
+        localtime_r(&now, &local_tm);
+#endif
+        (void)strftime(timestamp, sizeof(timestamp), "%H:%M:%S", &local_tm);
+        fprintf(stream, "[%s] %s | ", ce__log_level_label(level), timestamp);
+    }
+    else
+    {
+        fprintf(stream, "[%s] ", ce__log_level_label(level));
+    }
+
+#if defined(_MSC_VER)
+    len = (ce_size)_vsnprintf_s(buffer, sizeof(buffer), _TRUNCATE, fmt, args);
+#else
+    len = (ce_size)vsnprintf(buffer, sizeof(buffer), fmt, args);
+#endif
+
+    if (len >= (ce_size)sizeof(buffer))
+    {
+        buffer[sizeof(buffer) - 1U] = '\0';
+    }
+
+    fputs(buffer, stream);
+    fputc('\n', stream);
+    fflush(stream);
+
+    if (level >= CE_LOG_ERROR)
+    {
+        CE_RAISE_ERROR(CHAOS_ERR_UNKNOWN, buffer);
+    }
+}

--- a/ChaosEngine/src/platform/sdl/chaos_input_sdl.c
+++ b/ChaosEngine/src/platform/sdl/chaos_input_sdl.c
@@ -1,16 +1,368 @@
 /**
- * 
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░ 
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░   
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░ 
- * 
+ *
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░
+ *
  * @file chaos_input_sdl.c
- * @brief Implementation skeleton.
+ * @brief SDL2-backed input processing for ChaosEngine.
  */
 #include "platform/chaos_input.h"
 
-/* TODO: implement */
+#include "core/chaos_error.h"
+#include "utility/chaos_string.h"
+
+/* ************************************************************************** */
+/* INTERNAL HELPERS                                                           */
+/* ************************************************************************** */
+
+static ce_key ce__from_scancode(SDL_Scancode scancode)
+{
+    switch (scancode)
+    {
+        case SDL_SCANCODE_ESCAPE: return CE_KEY_ESCAPE;
+        case SDL_SCANCODE_SPACE:  return CE_KEY_SPACE;
+        case SDL_SCANCODE_RETURN: return CE_KEY_RETURN;
+        case SDL_SCANCODE_TAB:    return CE_KEY_TAB;
+        case SDL_SCANCODE_BACKSPACE: return CE_KEY_BACKSPACE;
+        case SDL_SCANCODE_LEFT:   return CE_KEY_LEFT;
+        case SDL_SCANCODE_RIGHT:  return CE_KEY_RIGHT;
+        case SDL_SCANCODE_UP:     return CE_KEY_UP;
+        case SDL_SCANCODE_DOWN:   return CE_KEY_DOWN;
+        case SDL_SCANCODE_A: return CE_KEY_A;
+        case SDL_SCANCODE_B: return CE_KEY_B;
+        case SDL_SCANCODE_C: return CE_KEY_C;
+        case SDL_SCANCODE_D: return CE_KEY_D;
+        case SDL_SCANCODE_E: return CE_KEY_E;
+        case SDL_SCANCODE_F: return CE_KEY_F;
+        case SDL_SCANCODE_G: return CE_KEY_G;
+        case SDL_SCANCODE_H: return CE_KEY_H;
+        case SDL_SCANCODE_I: return CE_KEY_I;
+        case SDL_SCANCODE_J: return CE_KEY_J;
+        case SDL_SCANCODE_K: return CE_KEY_K;
+        case SDL_SCANCODE_L: return CE_KEY_L;
+        case SDL_SCANCODE_M: return CE_KEY_M;
+        case SDL_SCANCODE_N: return CE_KEY_N;
+        case SDL_SCANCODE_O: return CE_KEY_O;
+        case SDL_SCANCODE_P: return CE_KEY_P;
+        case SDL_SCANCODE_Q: return CE_KEY_Q;
+        case SDL_SCANCODE_R: return CE_KEY_R;
+        case SDL_SCANCODE_S: return CE_KEY_S;
+        case SDL_SCANCODE_T: return CE_KEY_T;
+        case SDL_SCANCODE_U: return CE_KEY_U;
+        case SDL_SCANCODE_V: return CE_KEY_V;
+        case SDL_SCANCODE_W: return CE_KEY_W;
+        case SDL_SCANCODE_X: return CE_KEY_X;
+        case SDL_SCANCODE_Y: return CE_KEY_Y;
+        case SDL_SCANCODE_Z: return CE_KEY_Z;
+        case SDL_SCANCODE_0: return CE_KEY_0;
+        case SDL_SCANCODE_1: return CE_KEY_1;
+        case SDL_SCANCODE_2: return CE_KEY_2;
+        case SDL_SCANCODE_3: return CE_KEY_3;
+        case SDL_SCANCODE_4: return CE_KEY_4;
+        case SDL_SCANCODE_5: return CE_KEY_5;
+        case SDL_SCANCODE_6: return CE_KEY_6;
+        case SDL_SCANCODE_7: return CE_KEY_7;
+        case SDL_SCANCODE_8: return CE_KEY_8;
+        case SDL_SCANCODE_9: return CE_KEY_9;
+        case SDL_SCANCODE_LSHIFT: return CE_KEY_LSHIFT;
+        case SDL_SCANCODE_RSHIFT: return CE_KEY_RSHIFT;
+        case SDL_SCANCODE_LCTRL:  return CE_KEY_LCTRL;
+        case SDL_SCANCODE_RCTRL:  return CE_KEY_RCTRL;
+        case SDL_SCANCODE_LALT:   return CE_KEY_LALT;
+        case SDL_SCANCODE_RALT:   return CE_KEY_RALT;
+        default: return CE_KEY_UNKNOWN;
+    }
+}
+
+static ce_mouse_button ce__from_mouse_button(ce_u8 sdl_button)
+{
+    switch (sdl_button)
+    {
+        case SDL_BUTTON_LEFT:   return CE_MOUSE_LEFT;
+        case SDL_BUTTON_RIGHT:  return CE_MOUSE_RIGHT;
+        case SDL_BUTTON_MIDDLE: return CE_MOUSE_MIDDLE;
+        case SDL_BUTTON_X1:     return CE_MOUSE_X1;
+        case SDL_BUTTON_X2:     return CE_MOUSE_X2;
+        default:                return CE_MOUSE_LEFT;
+    }
+}
+
+/* ************************************************************************** */
+/* PUBLIC API                                                                 */
+/* ************************************************************************** */
+
+void ce_input_init(ce_input_state* state)
+{
+    if (state == (ce_input_state*)0)
+    {
+        return;
+    }
+
+    ce__memset(state, 0u, sizeof(*state));
+}
+
+void ce_input_new_frame(ce_input_state* state)
+{
+    ce_size i;
+
+    if (state == (ce_input_state*)0)
+    {
+        return;
+    }
+
+    for (i = 0; i < (ce_size)CE_KEY_COUNT; ++i)
+    {
+        state->key_pressed[i]  = CE_FALSE;
+        state->key_released[i] = CE_FALSE;
+    }
+
+    for (i = 0; i < (ce_size)CE_MOUSE_BUTTON_COUNT; ++i)
+    {
+        state->mouse_pressed[i]  = CE_FALSE;
+        state->mouse_released[i] = CE_FALSE;
+    }
+
+    state->mouse_delta_x = 0;
+    state->mouse_delta_y = 0;
+    state->scroll_x      = 0;
+    state->scroll_y      = 0;
+}
+
+void ce_input_handle_key(ce_input_state* state, ce_key key, ce_bool is_down)
+{
+    if ((state == (ce_input_state*)0) || (key <= CE_KEY_UNKNOWN) || (key >= CE_KEY_COUNT))
+    {
+        return;
+    }
+
+    if (is_down == CE_TRUE)
+    {
+        if (state->key_down[key] == CE_FALSE)
+        {
+            state->key_pressed[key] = CE_TRUE;
+        }
+        state->key_down[key] = CE_TRUE;
+    }
+    else
+    {
+        if (state->key_down[key] == CE_TRUE)
+        {
+            state->key_released[key] = CE_TRUE;
+        }
+        state->key_down[key] = CE_FALSE;
+    }
+}
+
+void ce_input_handle_mouse_button(ce_input_state* state, ce_mouse_button button, ce_bool is_down)
+{
+    if ((state == (ce_input_state*)0) || (button >= CE_MOUSE_BUTTON_COUNT))
+    {
+        return;
+    }
+
+    if (is_down == CE_TRUE)
+    {
+        if (state->mouse_down[button] == CE_FALSE)
+        {
+            state->mouse_pressed[button] = CE_TRUE;
+        }
+        state->mouse_down[button] = CE_TRUE;
+    }
+    else
+    {
+        if (state->mouse_down[button] == CE_TRUE)
+        {
+            state->mouse_released[button] = CE_TRUE;
+        }
+        state->mouse_down[button] = CE_FALSE;
+    }
+}
+
+void ce_input_handle_mouse_motion(ce_input_state* state, ce_s32 x, ce_s32 y, ce_s32 dx, ce_s32 dy)
+{
+    if (state == (ce_input_state*)0)
+    {
+        return;
+    }
+
+    state->mouse_x       = x;
+    state->mouse_y       = y;
+    state->mouse_delta_x += dx;
+    state->mouse_delta_y += dy;
+}
+
+void ce_input_handle_mouse_wheel(ce_input_state* state, ce_s32 dx, ce_s32 dy)
+{
+    if (state == (ce_input_state*)0)
+    {
+        return;
+    }
+
+    state->scroll_x += dx;
+    state->scroll_y += dy;
+}
+
+void ce_input_process_event(ce_input_state* state, const SDL_Event* event)
+{
+    ce_key          key;
+    ce_mouse_button button;
+
+    if ((state == (ce_input_state*)0) || (event == (const SDL_Event*)0))
+    {
+        return;
+    }
+
+    switch (event->type)
+    {
+        case SDL_KEYDOWN:
+            if (event->key.repeat == 0)
+            {
+                key = ce__from_scancode(event->key.keysym.scancode);
+                ce_input_handle_key(state, key, CE_TRUE);
+            }
+            break;
+        case SDL_KEYUP:
+            key = ce__from_scancode(event->key.keysym.scancode);
+            ce_input_handle_key(state, key, CE_FALSE);
+            break;
+        case SDL_MOUSEBUTTONDOWN:
+            button = ce__from_mouse_button(event->button.button);
+            ce_input_handle_mouse_button(state, button, CE_TRUE);
+            break;
+        case SDL_MOUSEBUTTONUP:
+            button = ce__from_mouse_button(event->button.button);
+            ce_input_handle_mouse_button(state, button, CE_FALSE);
+            break;
+        case SDL_MOUSEMOTION:
+            ce_input_handle_mouse_motion(state,
+                                         event->motion.x,
+                                         event->motion.y,
+                                         event->motion.xrel,
+                                         event->motion.yrel);
+            break;
+        case SDL_MOUSEWHEEL:
+            ce_input_handle_mouse_wheel(state, event->wheel.x, event->wheel.y);
+            break;
+        default:
+            break;
+    }
+}
+
+ce_bool ce_input_key_down(const ce_input_state* state, ce_key key)
+{
+    if ((state == (const ce_input_state*)0) || (key <= CE_KEY_UNKNOWN) || (key >= CE_KEY_COUNT))
+    {
+        return CE_FALSE;
+    }
+
+    return state->key_down[key];
+}
+
+ce_bool ce_input_key_pressed(const ce_input_state* state, ce_key key)
+{
+    if ((state == (const ce_input_state*)0) || (key <= CE_KEY_UNKNOWN) || (key >= CE_KEY_COUNT))
+    {
+        return CE_FALSE;
+    }
+
+    return state->key_pressed[key];
+}
+
+ce_bool ce_input_key_released(const ce_input_state* state, ce_key key)
+{
+    if ((state == (const ce_input_state*)0) || (key <= CE_KEY_UNKNOWN) || (key >= CE_KEY_COUNT))
+    {
+        return CE_FALSE;
+    }
+
+    return state->key_released[key];
+}
+
+ce_bool ce_input_mouse_down(const ce_input_state* state, ce_mouse_button button)
+{
+    if ((state == (const ce_input_state*)0) || (button >= CE_MOUSE_BUTTON_COUNT))
+    {
+        return CE_FALSE;
+    }
+
+    return state->mouse_down[button];
+}
+
+ce_bool ce_input_mouse_pressed(const ce_input_state* state, ce_mouse_button button)
+{
+    if ((state == (const ce_input_state*)0) || (button >= CE_MOUSE_BUTTON_COUNT))
+    {
+        return CE_FALSE;
+    }
+
+    return state->mouse_pressed[button];
+}
+
+ce_bool ce_input_mouse_released(const ce_input_state* state, ce_mouse_button button)
+{
+    if ((state == (const ce_input_state*)0) || (button >= CE_MOUSE_BUTTON_COUNT))
+    {
+        return CE_FALSE;
+    }
+
+    return state->mouse_released[button];
+}
+
+ce_s32 ce_input_mouse_x(const ce_input_state* state)
+{
+    if (state == (const ce_input_state*)0)
+    {
+        return 0;
+    }
+    return state->mouse_x;
+}
+
+ce_s32 ce_input_mouse_y(const ce_input_state* state)
+{
+    if (state == (const ce_input_state*)0)
+    {
+        return 0;
+    }
+    return state->mouse_y;
+}
+
+ce_s32 ce_input_mouse_delta_x(const ce_input_state* state)
+{
+    if (state == (const ce_input_state*)0)
+    {
+        return 0;
+    }
+    return state->mouse_delta_x;
+}
+
+ce_s32 ce_input_mouse_delta_y(const ce_input_state* state)
+{
+    if (state == (const ce_input_state*)0)
+    {
+        return 0;
+    }
+    return state->mouse_delta_y;
+}
+
+ce_s32 ce_input_scroll_x(const ce_input_state* state)
+{
+    if (state == (const ce_input_state*)0)
+    {
+        return 0;
+    }
+    return state->scroll_x;
+}
+
+ce_s32 ce_input_scroll_y(const ce_input_state* state)
+{
+    if (state == (const ce_input_state*)0)
+    {
+        return 0;
+    }
+    return state->scroll_y;
+}

--- a/ChaosEngine/src/platform/sdl/chaos_window_sdl.c
+++ b/ChaosEngine/src/platform/sdl/chaos_window_sdl.c
@@ -1,16 +1,179 @@
 /**
- * 
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░ 
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░   
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░ 
- * 
+ *
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░
+ *
  * @file chaos_window_sdl.c
- * @brief Implementation skeleton.
+ * @brief SDL2 backend for ChaosEngine window utilities.
  */
 #include "platform/chaos_window.h"
 
-/* TODO: implement */
+#include "core/chaos_log.h"
+
+#include <stdio.h>
+
+ce_result ce_window_create(const ce_window_config* config, ce_window* out_window)
+{
+    ce_result result;
+    ce_u32    window_flags;
+    ce_u32    renderer_flags;
+
+    result = CE_OK;
+    window_flags = SDL_WINDOW_SHOWN;
+    renderer_flags = SDL_RENDERER_ACCELERATED;
+
+    if ((config == (const ce_window_config*)0) || (out_window == (ce_window*)0))
+    {
+        CE_RAISE_ERROR(CHAOS_ERR_INVALID_ARGUMENT, "ce_window_create invalid arguments");
+        result = (ce_result)(-((ce_s32)CHAOS_ERR_INVALID_ARGUMENT));
+    }
+    else
+    {
+        if (config->resizable == CE_TRUE)
+        {
+            window_flags |= SDL_WINDOW_RESIZABLE;
+        }
+
+        if (config->vsync == CE_TRUE)
+        {
+            renderer_flags |= SDL_RENDERER_PRESENTVSYNC;
+        }
+
+        out_window->native_window = SDL_CreateWindow(config->title != (const ce_char*)0 ? config->title : "ChaosEngine",
+                                                     SDL_WINDOWPOS_CENTERED,
+                                                     SDL_WINDOWPOS_CENTERED,
+                                                     config->width,
+                                                     config->height,
+                                                     window_flags);
+        if (out_window->native_window == (SDL_Window*)0)
+        {
+            CE_RAISE_ERROR(CHAOS_ERR_WINDOW_CREATION_FAILED, SDL_GetError());
+            result = (ce_result)(-((ce_s32)CHAOS_ERR_WINDOW_CREATION_FAILED));
+        }
+        else
+        {
+            out_window->native_renderer = SDL_CreateRenderer(out_window->native_window, -1, renderer_flags);
+            if (out_window->native_renderer == (SDL_Renderer*)0)
+            {
+                CE_RAISE_ERROR(CHAOS_ERR_GFX_INIT_FAILED, SDL_GetError());
+                SDL_DestroyWindow(out_window->native_window);
+                out_window->native_window = (SDL_Window*)0;
+                result = (ce_result)(-((ce_s32)CHAOS_ERR_GFX_INIT_FAILED));
+            }
+            else
+            {
+                out_window->config = *config;
+                ce_window_set_clear_color(out_window, ce_color_rgb(16u, 16u, 32u));
+                CE_LOG_INFO("Window created: %dx%d", config->width, config->height);
+            }
+        }
+    }
+
+    return result;
+}
+
+void ce_window_destroy(ce_window* window)
+{
+    if (window == (ce_window*)0)
+    {
+        return;
+    }
+
+    if (window->native_renderer != (SDL_Renderer*)0)
+    {
+        SDL_DestroyRenderer(window->native_renderer);
+        window->native_renderer = (SDL_Renderer*)0;
+    }
+
+    if (window->native_window != (SDL_Window*)0)
+    {
+        SDL_DestroyWindow(window->native_window);
+        window->native_window = (SDL_Window*)0;
+    }
+}
+
+void ce_window_set_clear_color(ce_window* window, ce_color color)
+{
+    if (window == (ce_window*)0)
+    {
+        return;
+    }
+
+    window->clear_color = color;
+}
+
+void ce_window_clear(ce_window* window)
+{
+    if ((window == (ce_window*)0) || (window->native_renderer == (SDL_Renderer*)0))
+    {
+        return;
+    }
+
+    SDL_SetRenderDrawColor(window->native_renderer,
+                           window->clear_color.r,
+                           window->clear_color.g,
+                           window->clear_color.b,
+                           window->clear_color.a);
+    SDL_RenderClear(window->native_renderer);
+}
+
+void ce_window_present(ce_window* window)
+{
+    if ((window == (ce_window*)0) || (window->native_renderer == (SDL_Renderer*)0))
+    {
+        return;
+    }
+
+    SDL_RenderPresent(window->native_renderer);
+}
+
+void ce_window_draw_filled_rect(ce_window* window, ce_s32 x, ce_s32 y, ce_s32 w, ce_s32 h, ce_color color)
+{
+    SDL_Rect rect;
+
+    if ((window == (ce_window*)0) || (window->native_renderer == (SDL_Renderer*)0))
+    {
+        return;
+    }
+
+    rect.x = x;
+    rect.y = y;
+    rect.w = w;
+    rect.h = h;
+
+    SDL_SetRenderDrawColor(window->native_renderer, color.r, color.g, color.b, color.a);
+    SDL_RenderFillRect(window->native_renderer, &rect);
+}
+
+void ce_window_draw_rect(ce_window* window, ce_s32 x, ce_s32 y, ce_s32 w, ce_s32 h, ce_color color)
+{
+    SDL_Rect rect;
+
+    if ((window == (ce_window*)0) || (window->native_renderer == (SDL_Renderer*)0))
+    {
+        return;
+    }
+
+    rect.x = x;
+    rect.y = y;
+    rect.w = w;
+    rect.h = h;
+
+    SDL_SetRenderDrawColor(window->native_renderer, color.r, color.g, color.b, color.a);
+    SDL_RenderDrawRect(window->native_renderer, &rect);
+}
+
+SDL_Renderer* ce_window_renderer(ce_window* window)
+{
+    if (window == (ce_window*)0)
+    {
+        return (SDL_Renderer*)0;
+    }
+
+    return window->native_renderer;
+}

--- a/ChaosEngine/src/runtime/chaos_engine.c
+++ b/ChaosEngine/src/runtime/chaos_engine.c
@@ -1,16 +1,335 @@
 /**
- * 
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░ 
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░   
- * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
- * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░ 
- * 
+ *
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░ ░▒▓██████▓▒░ ░▒▓███████▓▒  ▒▓████████▓▒░▒▓███████▓▒░ ░▒▓██████▓▒░░▒▓█▓▒░▒▓███████▓▒░░▒▓████████▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░      ░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░      ░▒▓████████▓▒░▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░  ▒▓██████▓▒░ ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒▒▓███▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓██████▓▒░
+ * ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░      ░▒▓█▓▒  ▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░
+ * ░▒▓██████▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓███████▓▒░  ▒▓████████▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓██████▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░▒▓████████▓▒░
+ *
  * @file chaos_engine.c
- * @brief Implementation skeleton.
+ * @brief Implementation of the ChaosEngine runtime loop.
  */
 #include "runtime/chaos_engine.h"
 
-/* TODO: implement */
+#include <SDL2/SDL.h>
+
+#include "utility/chaos_string.h"
+
+/* ************************************************************************** */
+/* INTERNAL CONSTANTS                                                         */
+/* ************************************************************************** */
+
+#define CE_DEFAULT_WIDTH  1280
+#define CE_DEFAULT_HEIGHT 720
+#define CE_DEFAULT_FPS    60u
+#define CE_MAX_DT_CLAMP   0.25f
+
+/* ************************************************************************** */
+/* INTERNAL HELPERS                                                           */
+/* ************************************************************************** */
+
+static void ce__engine_reset(ce_engine* engine)
+{
+    if (engine == (ce_engine*)0)
+    {
+        return;
+    }
+
+    ce__memset(engine, 0u, sizeof(*engine));
+}
+
+static ce_result ce__engine_init_sdl(void)
+{
+    ce_result result;
+
+    result = CE_OK;
+
+    if (SDL_WasInit(0) == 0)
+    {
+        if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_EVENTS) != 0)
+        {
+            CE_RAISE_ERROR(CHAOS_ERR_PLATFORM_INIT_FAILED, SDL_GetError());
+            result = (ce_result)(-((ce_s32)CHAOS_ERR_PLATFORM_INIT_FAILED));
+        }
+    }
+
+    return result;
+}
+
+static void ce__engine_shutdown_sdl(void)
+{
+    SDL_Quit();
+}
+
+static void ce__engine_apply_config_defaults(ce_engine_config* config)
+{
+    if (config == (ce_engine_config*)0)
+    {
+        return;
+    }
+
+    if (config->window.width <= 0)
+    {
+        config->window.width = CE_DEFAULT_WIDTH;
+    }
+
+    if (config->window.height <= 0)
+    {
+        config->window.height = CE_DEFAULT_HEIGHT;
+    }
+
+    if (config->window.title == (const ce_char*)0)
+    {
+        config->window.title = "ChaosEngine";
+    }
+
+    if (config->target_fps == 0u)
+    {
+        config->target_fps = CE_DEFAULT_FPS;
+    }
+
+    if (config->max_updates_per_frame == 0u)
+    {
+        config->max_updates_per_frame = 5u;
+    }
+}
+
+static void ce__engine_sleep_for_fps(ce_u32 target_fps, ce_f32 frame_time)
+{
+    ce_f32 target_dt;
+
+    if (target_fps == 0u)
+    {
+        return;
+    }
+
+    target_dt = 1.0f / (ce_f32)target_fps;
+    if (frame_time < target_dt)
+    {
+        ce_f32 remaining = target_dt - frame_time;
+        if (remaining > 0.0f)
+        {
+            SDL_Delay((ce_u32)(remaining * 1000.0f));
+        }
+    }
+}
+
+/* ************************************************************************** */
+/* PUBLIC API                                                                 */
+/* ************************************************************************** */
+
+ce_engine_config ce_engine_config_default(void)
+{
+    ce_engine_config cfg;
+
+    cfg.window.title     = "ChaosEngine";
+    cfg.window.width     = CE_DEFAULT_WIDTH;
+    cfg.window.height    = CE_DEFAULT_HEIGHT;
+    cfg.window.resizable = CE_TRUE;
+    cfg.window.vsync     = CE_TRUE;
+    cfg.target_fps       = CE_DEFAULT_FPS;
+    cfg.max_updates_per_frame = 5u;
+
+    return cfg;
+}
+
+ce_result ce_engine_run(const ce_engine_config* config, const ce_engine_callbacks* callbacks, void* user_data)
+{
+    ce_engine        engine;
+    ce_engine_config cfg;
+    ce_result        result;
+    ce_bool          initialized;
+    ce_bool          running;
+
+    if ((config == (const ce_engine_config*)0) || (callbacks == (const ce_engine_callbacks*)0))
+    {
+        CE_RAISE_ERROR(CHAOS_ERR_INVALID_ARGUMENT, "ce_engine_run invalid args");
+        return (ce_result)(-((ce_s32)CHAOS_ERR_INVALID_ARGUMENT));
+    }
+
+    if (callbacks->on_update == (ce_engine_update_fn)0)
+    {
+        CE_RAISE_ERROR(CHAOS_ERR_ENGINE_LOOP_FAILED, "Update callback is mandatory");
+        return (ce_result)(-((ce_s32)CHAOS_ERR_ENGINE_LOOP_FAILED));
+    }
+
+    cfg = *config;
+    ce__engine_apply_config_defaults(&cfg);
+
+    ce__engine_reset(&engine);
+    engine.config    = cfg;
+    engine.callbacks = *callbacks;
+    engine.user_data = user_data;
+
+    result = ce__engine_init_sdl();
+    if (CE_FAILED(result))
+    {
+        return result;
+    }
+
+    initialized = CE_TRUE;
+
+    if (CE_SUCCEEDED(result))
+    {
+        ce_error_global();
+        ce_time_init();
+        ce_input_init(&engine.input);
+
+        result = ce_window_create(&engine.config.window, &engine.window);
+        if (CE_FAILED(result))
+        {
+            initialized = CE_FALSE;
+        }
+    }
+
+    if ((initialized == CE_TRUE) && (engine.callbacks.on_init != (ce_engine_init_fn)0))
+    {
+        if (engine.callbacks.on_init(&engine, user_data) == CE_FALSE)
+        {
+            CE_RAISE_ERROR(CHAOS_ERR_ENGINE_NOT_INITIALIZED, "Engine init callback failed");
+            initialized = CE_FALSE;
+            result = (ce_result)(-((ce_s32)CHAOS_ERR_ENGINE_NOT_INITIALIZED));
+        }
+    }
+
+    if (initialized == CE_FALSE)
+    {
+        ce_window_destroy(&engine.window);
+        ce_time_shutdown();
+        ce__engine_shutdown_sdl();
+        return result;
+    }
+
+    engine.running     = CE_TRUE;
+    engine.fixed_dt    = 1.0f / (ce_f32)engine.config.target_fps;
+    engine.accumulator = 0.0f;
+    engine.elapsed_time = 0.0f;
+    engine.frame_index  = 0u;
+
+    running = CE_TRUE;
+
+    while (running == CE_TRUE)
+    {
+        ce_f32 frame_dt;
+        ce_u32 updates_performed;
+        ce_f32 alpha;
+        ce_f32 frame_start_delta;
+        Uint64 frame_start_ticks;
+        SDL_Event evt;
+
+        frame_start_ticks = SDL_GetPerformanceCounter();
+
+        ce_input_new_frame(&engine.input);
+
+        while (SDL_PollEvent(&evt) == 1)
+        {
+            if (evt.type == SDL_QUIT)
+            {
+                engine.running = CE_FALSE;
+            }
+            ce_input_process_event(&engine.input, &evt);
+        }
+
+        ce_time_update();
+        frame_dt = ce_time_get_delta();
+        if (frame_dt > CE_MAX_DT_CLAMP)
+        {
+            frame_dt = CE_MAX_DT_CLAMP;
+        }
+
+        engine.accumulator += frame_dt;
+        engine.elapsed_time += frame_dt;
+        updates_performed = 0u;
+
+        while ((engine.accumulator >= engine.fixed_dt) && (updates_performed < engine.config.max_updates_per_frame))
+        {
+            engine.callbacks.on_update(&engine, engine.user_data, engine.fixed_dt);
+            engine.accumulator -= engine.fixed_dt;
+            updates_performed++;
+        }
+
+        alpha = (engine.fixed_dt > 0.0f) ? (engine.accumulator / engine.fixed_dt) : 0.0f;
+
+        if (engine.callbacks.on_render != (ce_engine_render_fn)0)
+        {
+            ce_window_clear(&engine.window);
+            engine.callbacks.on_render(&engine, engine.user_data, alpha);
+            ce_window_present(&engine.window);
+        }
+
+        engine.frame_index++;
+
+        frame_start_delta = (ce_f32)(SDL_GetPerformanceCounter() - frame_start_ticks) /
+                            (ce_f32)SDL_GetPerformanceFrequency();
+
+        if (engine.config.window.vsync == CE_FALSE)
+        {
+            ce__engine_sleep_for_fps(engine.config.target_fps, frame_start_delta);
+        }
+
+        running = engine.running;
+    }
+
+    if (engine.callbacks.on_shutdown != (ce_engine_shutdown_fn)0)
+    {
+        engine.callbacks.on_shutdown(&engine, engine.user_data);
+    }
+
+    ce_window_destroy(&engine.window);
+    ce_time_shutdown();
+    ce__engine_shutdown_sdl();
+
+    return result;
+}
+
+void ce_engine_request_exit(ce_engine* engine)
+{
+    if (engine == (ce_engine*)0)
+    {
+        return;
+    }
+
+    engine->running = CE_FALSE;
+}
+
+const ce_input_state* ce_engine_input(const ce_engine* engine)
+{
+    if (engine == (const ce_engine*)0)
+    {
+        return (const ce_input_state*)0;
+    }
+
+    return &engine->input;
+}
+
+ce_window* ce_engine_window(ce_engine* engine)
+{
+    if (engine == (ce_engine*)0)
+    {
+        return (ce_window*)0;
+    }
+
+    return &engine->window;
+}
+
+ce_f32 ce_engine_elapsed_time(const ce_engine* engine)
+{
+    if (engine == (const ce_engine*)0)
+    {
+        return 0.0f;
+    }
+
+    return engine->elapsed_time;
+}
+
+ce_u64 ce_engine_frame_index(const ce_engine* engine)
+{
+    if (engine == (const ce_engine*)0)
+    {
+        return 0u;
+    }
+
+    return engine->frame_index;
+}


### PR DESCRIPTION
## Summary
- implement a minimal logging API and expose configuration/callback plumbing for the engine runtime
- add SDL-backed window and input helpers plus the fixed-timestep engine loop that clears, updates, and renders frames
- refresh the boot example to exercise the new loop with keyboard input and simple rendering

## Testing
- `make -f cmake/Makefile run EXAMPLE=00_boot` *(fails: SDL2 development headers are not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ead5ec5ae08332b2c01492f1445e12